### PR TITLE
add dynamic array branch tests and mocks

### DIFF
--- a/src/DynamicArray.dfy
+++ b/src/DynamicArray.dfy
@@ -1,0 +1,132 @@
+/* 
+    The following code is originally authored by the Secure Foundations Lab.
+    It is part of a project to implement the QUIC protocol layer in Dafny.
+    The original source can be found here:
+    https://github.com/secure-foundations/everquic-dafny/tree/master/src
+
+    For testing purposes, we have made modifications that strengthen 
+    certain postconditions.
+*/
+
+include "NativeTypes.dfy"
+include "Extern.dfy"
+
+module DynamicArray {
+    
+    import opened NativeTypes
+    import opened Extern
+
+    export
+        reveals Vector
+        provides Vector._ctor, Vector.Valid, Vector.buffer, Vector.current_capacity, 
+            Vector.extend_buffer, Vector.current_size, Vector.push_back, Vector.get_size,
+            Vector.at_index, Vector.clear
+        provides NativeTypes
+        provides Vector.DEFAULT_SIZE
+
+
+    class Vector<T>
+    {
+        static const DEFAULT_SIZE :uint32 := 16
+        var buffer :array<T>
+        var current_capacity :uint32
+        var current_size :uint32
+
+        predicate Valid()
+            reads this, buffer
+        {
+            && current_capacity >= DEFAULT_SIZE
+            && current_capacity as int == buffer.Length
+            && current_size < current_capacity
+        }
+
+        method get_size() returns (x:uint32)
+            ensures x == current_size
+        {
+            return current_size;
+        }
+
+        method at_index(index:uint32) returns (x:T)
+            requires Valid()
+            requires index < current_size
+            ensures x == buffer[index]
+        {
+            return buffer[index];
+        }
+
+        method extend_buffer(value:T)
+            requires Valid()
+            modifies this
+            ensures Valid()
+            ensures fresh(buffer)
+            ensures current_size as int < current_capacity as int - 1
+            ensures current_size == old(current_size)
+        {
+            if current_capacity >= UINT32_MAX / 2 {
+              fatal("at max capacity");
+              return;
+            }
+            var old_buffer := this.buffer;
+            var old_size := this.current_capacity;
+
+            current_capacity := old_size * 2;
+            buffer := newArrayFill(current_capacity as uint64, value);
+
+            assert current_size < current_capacity - 1;
+
+            var i := 0;
+            while i < old_size
+                invariant Valid()
+                invariant current_capacity > old_size
+                invariant i < current_capacity
+                invariant i < old_size
+                invariant fresh(buffer)
+                invariant current_size < current_capacity - 1
+                invariant current_size == old(current_size)
+                decreases old_size as int - i as int
+            {
+                buffer[i] := old_buffer[i];
+
+                if i == old_size - 1 {
+                    break;
+                }
+                i := i + 1;
+            }
+        }
+
+        method push_back(value:T)
+            requires Valid();
+            modifies this, this.buffer;
+            ensures fresh(buffer) || buffer == old(buffer);
+            ensures Valid();
+            ensures old(current_size as int) < buffer.Length
+            ensures buffer[old(current_size)] == value
+            ensures current_size == old(current_size) + 1
+        {
+            if current_size + 1 == current_capacity {
+                extend_buffer(value);
+            }
+            buffer[current_size] := value;
+            current_size := current_size + 1;
+        }
+
+        method clear()
+            requires Valid()
+            modifies this`current_size
+            ensures Valid()
+            ensures current_size == 0
+        {
+            current_size := 0;
+        }
+
+        constructor(default_val:T)
+            ensures Valid()
+            ensures fresh(buffer)
+        {
+            current_size := 0;
+            current_capacity := DEFAULT_SIZE;
+            new;
+            buffer := newArrayFill(16, default_val);
+        }
+    }
+}

--- a/src/Extern.dfy
+++ b/src/Extern.dfy
@@ -1,0 +1,24 @@
+/* 
+    The following code is originally authored by the Secure Foundations Lab.
+    It is part of a project to implement the QUIC protocol layer in Dafny.
+    The original source can be found here:
+    https://github.com/secure-foundations/everquic-dafny/tree/master/src
+*/
+
+include "NativeTypes.dfy"
+
+module {:extern "Extern"} Extern {
+  import opened NativeTypes
+
+method {:extern "Extern", "newArrayFill"} newArrayFill<T>(n: uint64, t: T) returns (ar: array<T>)
+  ensures ar.Length == n as int
+  ensures forall i | 0 <= i < n :: ar[i] == t
+  ensures fresh(ar)
+
+
+  method {:extern "Extern", "fatal"} fatal(m:string)
+    ensures false
+
+  method {:extern "Extern", "fatal_assume"} fatal_assume(ghost b:bool)
+    ensures b;
+}

--- a/src/NativeTypes.dfy
+++ b/src/NativeTypes.dfy
@@ -1,0 +1,93 @@
+/* 
+    The following code is originally authored by the Secure Foundations Lab.
+    It is part of a project to implement the QUIC protocol layer in Dafny.
+    The original source can be found here:
+    https://github.com/secure-foundations/everquic-dafny/tree/master/src
+*/
+
+module NativeTypes {
+    newtype{:nativeType "sbyte"} sbyte = i:int | -0x80 <= i < 0x80
+    newtype{:nativeType "byte"} byte = i:int | 0 <= i < 0x100
+    newtype{:nativeType "short"} int16 = i:int | -0x8000 <= i < 0x8000
+    newtype{:nativeType "ushort"} uint16 = i:int | 0 <= i < 0x10000
+    newtype{:nativeType "int"} int32 = i:int | -0x80000000 <= i < 0x80000000
+    newtype{:nativeType "uint"} uint32 = i:int | 0 <= i < 0x100000000
+    newtype{:nativeType "long"} int64 = i:int | -0x8000000000000000 <= i < 0x8000000000000000
+    newtype{:nativeType "ulong"} uint64 = i:int | 0 <= i < 0x10000000000000000
+    newtype{:nativeType "sbyte"} nat8 = i:int | 0 <= i < 0x80
+    newtype{:nativeType "short"} nat16 = i:int | 0 <= i < 0x8000
+    newtype{:nativeType "int"} nat32 = i:int | 0 <= i < 0x80000000
+    newtype{:nativeType "long"} nat64 = i:int | 0 <= i < 0x8000000000000000
+
+    const UINT62_MAX :uint64 := 0x3fffffffffffffff
+    const UINT64_MAX :uint64 := 0xffffffffffffffff;
+    const UINT32_MAX :uint32 := 0xffffffff;
+    const UINT16_MAX :uint16 := 0xffff;
+    const INT64_MAX : int64 := 0x7fffffffffffffff;
+    const INT64_MIN : int64 := -0x7fffffffffffffff;
+
+    type uint2 = i:uint64 | 0 <= i < 4
+    type uint62 = i: uint64 | 0 <= i <= UINT62_MAX
+
+    type uint8 = byte
+
+    function method {:extern "NativeTypes", "xor8"} xor8(x:uint8, y:uint8) : uint8
+
+    function method {:extern "NativeTypes", "xor16"} xor16(x:uint16, y:uint16) : uint16
+    function method {:extern "NativeTypes", "xor32"} xor32(x:uint32, y:uint32) : uint32
+    function method {:extern "NativeTypes", "xor64"} xor64(x:uint64, y:uint64) : uint64
+
+    function method {:extern "NativeTypes", "or8"} or8(x:uint8, y:uint8) : uint8
+    function method {:extern "NativeTypes", "or16"} or16(x:uint16, y:uint16) : uint16
+    function method {:extern "NativeTypes", "or32"} or32(x:uint32, y:uint32) : uint32
+    function method {:extern "NativeTypes", "or64"} or64(x:uint64, y:uint64) : uint64
+
+    function method {:extern "NativeTypes", "and8"} and8(x:uint8, y:uint8) : (r:uint8)
+      ensures r <= x;
+      ensures r <= y;
+
+    function method {:extern "NativeTypes", "and16"} and16(x:uint16, y:uint16) : uint16
+    function method {:extern "NativeTypes", "and32"} and32(x:uint32, y:uint32) : uint32
+    function method {:extern "NativeTypes", "and64"} and64(x:uint64, y:uint64) : (r:uint64)
+      ensures r <= x;
+      ensures r <= y;
+
+    function method {:extern "NativeTypes", "lshift8"} lshift8(x:uint8, y:uint8) : uint8
+    function method {:extern "NativeTypes", "lshift16"} lshift16(x:uint16, y:uint16) : uint16
+    function method {:extern "NativeTypes", "lshift32"} lshift32(x:uint32, y:uint32) : uint32
+    function method {:extern "NativeTypes", "lshift64"} lshift64(x:uint64, y:uint64) : uint64
+
+    function method {:extern "NativeTypes", "not64"} not64(x:uint64) : uint64
+
+    // Compute max of two values
+    function method maxi64 (x:int64, y:int64): (r:int64)
+      ensures r >= x;
+      ensures r >= y;
+    {
+        if x > y then x else y
+    }
+
+    // Compute max of two values
+    function method maxu64 (x:uint64, y:uint64): (r:uint64)
+      ensures r >= x;
+      ensures r >= y;
+    {
+        if x > y then x else y
+    }
+
+    // Compute min of two values
+    function method minu32 (x:uint32, y:uint32): (r:uint32)
+      ensures r <= x;
+      ensures r <= y;
+    {
+        if x > y then y else x
+    }
+
+    // Compute min of two values
+    function method minu64 (x:uint64, y:uint64): (r:uint64)
+      ensures r <= x;
+      ensures r <= y;
+    {
+        if x > y then y else x
+    }
+}

--- a/test/DynamicArrayMock.dfy
+++ b/test/DynamicArrayMock.dfy
@@ -1,0 +1,18 @@
+include "../src/DynamicArray.dfy"
+
+module {:extern "DynamicArrayMock"} DynamicArrayMock {
+
+    import opened DynamicArray
+
+    method {:extern "DynamicArrayMock", "mock_dynamicArray"} mock_dynamicArray<T>() returns (arr : Vector<T>)
+        ensures arr.Valid()
+        ensures fresh(arr)
+        ensures fresh(arr.buffer)
+
+    method {:extern "DynamicArrayMock", "when_push_back"} when_push_back<T>(arr : Vector<T>, val:T)
+        ensures arr.Valid()
+        ensures 0 < arr.current_size as int < arr.buffer.Length
+        ensures arr.buffer[arr.current_size as int - 1] == val
+        ensures arr.current_size as int == old(arr.current_size) as int + 1
+
+}

--- a/test/DynamicArrayTest.dfy
+++ b/test/DynamicArrayTest.dfy
@@ -1,0 +1,99 @@
+include "../src/DynamicArray.dfy"
+include "DynamicArrayMock.dfy"
+include "../src/NativeTypes.dfy"
+
+module DynamicArrayTest {
+    
+    import opened DynamicArray
+    import opened Extern
+    import opened NativeTypes
+    import opened DynamicArrayMock
+
+        method get_size_should_returnCurrentSize() 
+        {
+            var arr := mock_dynamicArray();
+            assume arr.current_size == 0;
+            when_push_back(arr, 4);
+
+            var result := arr.get_size();
+
+            assert result == 1;
+        }
+
+        method at_index_should_returnValueAtGivenIndex() 
+        {
+            var arr := mock_dynamicArray();
+            var oracleValue := 4;
+            when_push_back(arr, oracleValue);
+            var index := 2;
+            assume index < arr.current_size;
+
+            var result := arr.at_index(index);
+
+            assert result == arr.buffer[index];
+        }
+
+        method extend_buffer_should_throwFatal_when_CapacityIsExtendedToMax()
+        {
+            var arr := mock_dynamicArray();
+            assume arr.current_capacity == UINT32_MAX;
+
+            arr.extend_buffer(4);
+        }
+
+        method extend_buffer_should_extendBufferThenStop_when_CapacityStaysUnderMax()
+        {
+            var arr := mock_dynamicArray();
+            var currentSizeBeforeCall := arr.current_size;
+
+            arr.extend_buffer(4);
+
+            assert fresh(arr.buffer);
+            assert arr.current_size < arr.current_capacity;
+            assert arr.current_size == currentSizeBeforeCall;
+        }
+
+
+        method push_back_should_notExtendBuffer_when_sizeIsNotOneLessThanCapacity()
+        {
+            var arr := mock_dynamicArray();
+            assume arr.current_capacity == 32;
+            assume arr.current_size == 16;
+            var currentSizeBeforeCall := arr.current_size;
+            var oracleValue := 7;
+
+            arr.push_back(oracleValue);
+
+            assert fresh(arr.buffer) || arr.buffer == old(arr.buffer);
+            assert arr.Valid();
+            assert currentSizeBeforeCall as int < arr.buffer.Length;
+            assert arr.buffer[currentSizeBeforeCall] == oracleValue;
+            assert arr.current_size == currentSizeBeforeCall + 1;
+        }
+
+        method push_back_should_extendBuffer_when_sizeIsOneLessThanCapacity()
+        {
+            var arr := mock_dynamicArray();
+            assume arr.current_capacity == 32;
+            assume arr.current_size == arr.current_capacity - 1;
+            var currentSizeBeforeCall := arr.current_size;
+
+            arr.push_back(7);
+
+            assert fresh(arr.buffer) || arr.buffer == old(arr.buffer);
+            assert arr.Valid();
+            assert currentSizeBeforeCall as int < arr.buffer.Length;
+            assert arr.buffer[currentSizeBeforeCall] == 7;
+        }
+
+        method clear_should_ModifyCurrentSizeToZero() 
+        {
+            var arr := mock_dynamicArray();
+            when_push_back(arr, 'c');
+
+            arr.clear();
+
+            assert arr.Valid();
+            assert arr.current_size == 0;
+        }
+}


### PR DESCRIPTION
This pull request adds full path coverage to the Secure Foundation Lab's DynamicArray Dafny model.  Each test follows the assume -> call test method -> assert approach.  All postconditions listed have a corresponding assertion statement in that method's test(s).    In some cases, the postconditions were too weak to ensure some very apparent behaviors.  These were modified.

You'll notice an external file called DynamicArrayMock that provides a mock object factory and a method equivalent in application to Mockito's "when()".

In white box testing, I'm not sure how feasible it is for the test object to export all fields and methods so they can be easily be accessed by the object's test methods.  On one hand, sometimes the postconditions are ensuring properties about internal state variables which we want to verify, so our test method should have access to such fields.  On the other hand, a more appropriate and more Java-like approach would be to not allow access to fields.  Perhaps a nice compromise would be to add some getters in DynamicArray.  @ericmercer Please let me know if you would like me to make this change.